### PR TITLE
Create CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+chicago.pydata.org


### PR DESCRIPTION
Required to map chicago.pydata.org to this repository.
